### PR TITLE
More accurate receivedMessage

### DIFF
--- a/WhatsappTray/WhatsAppApi.cpp
+++ b/WhatsappTray/WhatsAppApi.cpp
@@ -178,7 +178,7 @@ void WhatsAppApi::IndexedDbChanged(const DWORD dwAction, std::string strFilename
 		Logger::Debug(MODULE_NAME "IndexedDbChanged() - Found recv: '%s'", lineBuffer.c_str());
 
 		// Match: recv: [0-9a-f]{16}[.]--[0-9a-f]+\"\ttimestampN
-		if (std::regex_search(lineBuffer.c_str(), std::regex("recv: [0-9a-f]{16}[.]--[0-9a-f]+\"\\ttimestampN"))) {
+		if (std::regex_search(lineBuffer.c_str(), std::regex("recv: [0-9a-f]{16}"))) {
 			Logger::Debug(MODULE_NAME "IndexedDbChanged() - Found match for receivedMessage.");
 
 			if (receivedMessageEvent) {


### PR DESCRIPTION
At least after a few tests, simplifying the regex to the 16-digits only, reduces the amount of messages that matches for receivedMessage