### PR TITLE
Add additional check for WhatsApp (Outdated) window title to work wit…

### DIFF
--- a/WhatsappTray/Hook.cpp
+++ b/WhatsappTray/Hook.cpp
@@ -159,6 +159,12 @@ DWORD WINAPI Init(LPVOID lpParam)
 	}
 
 	_whatsAppWindowHandle = GetTopLevelWindowhandleWithName(WHATSAPP_CLIENT_NAME);
+	if(_whatsAppWindowHandle == nullptr)
+	{
+		LogString("WhatsApp window not found, checking for outdated version");
+		_whatsAppWindowHandle = GetTopLevelWindowhandleWithName(WHATSAPP_OUTDATED_CLIENT_NAME);
+	}
+
 	auto windowTitle = GetWindowTitle(_whatsAppWindowHandle);
 
 	LogString("Attached in window '%s' _whatsAppWindowHandle: 0x%08X", windowTitle.c_str(), _whatsAppWindowHandle);
@@ -437,11 +443,11 @@ LRESULT CALLBACK CallWndRetProc(int nCode, WPARAM wParam, LPARAM lParam)
 */
 static HWND GetTopLevelWindowhandleWithName(std::string searchedWindowTitle)
 {
-	HWND iteratedHwnd = NULL;
+	HWND iteratedHwnd = nullptr;
 	while (true) {
-		iteratedHwnd = FindWindowExA(NULL, iteratedHwnd, NULL, WHATSAPP_CLIENT_NAME);
-		if (iteratedHwnd == NULL) {
-			return NULL;
+		iteratedHwnd = FindWindowExA(nullptr, iteratedHwnd, nullptr, searchedWindowTitle.c_str());
+		if (iteratedHwnd == nullptr) {
+			return nullptr;
 		}
 
 		DWORD processId;
@@ -462,7 +468,7 @@ static HWND GetTopLevelWindowhandleWithName(std::string searchedWindowTitle)
 
 		auto windowTitle = GetWindowTitle(iteratedHwnd);
 		// Also check length because compare also matches strings that are longer like 'WhatsApp Voip'
-		if (windowTitle.compare(searchedWindowTitle) != 0 || windowTitle.length() != strlen(WHATSAPP_CLIENT_NAME)) {
+		if (windowTitle.compare(searchedWindowTitle) != 0 || windowTitle.length() != searchedWindowTitle.length()) {
 			//LogString("windowTitle='" + windowTitle + "' does not match '" WHATSAPP_CLIENT_NAME "'");
 			continue;
 		}

--- a/WhatsappTray/SharedDefines.h
+++ b/WhatsappTray/SharedDefines.h
@@ -5,6 +5,7 @@
 
 #define NAME TEXT("WhatsappTray")
 #define WHATSAPP_CLIENT_NAME TEXT("WhatsApp")
+#define WHATSAPP_OUTDATED_CLIENT_NAME TEXT("WhatsApp (Outdated)")
 #define WHATSAPPTRAY_LOAD_LIBRARY_TEST_ENV_VAR "WhatsappTrayLoadLibraryTest" /* The enviroment-variable used to test if the hook.dll was triggerd by WhatsappTray's LoadLibrary() */
 #define WHATSAPPTRAY_LOAD_LIBRARY_TEST_ENV_VAR_VALUE "TRUE" /* The value of the enviroment-variable used to test if the hook.dll was triggerd by WhatsappTray's LoadLibrary() */
 

--- a/WhatsappTray/WhatsappTray.cpp
+++ b/WhatsappTray/WhatsappTray.cpp
@@ -389,11 +389,16 @@ static HWND StartWhatsapp()
  */
 static HWND FindWhatsappWindowHandle()
 {
-	HWND iteratedHwnd = NULL;
+	HWND iteratedHwnd = nullptr;
+	bool outdated = false;
 	while (true) {
-		iteratedHwnd = FindWindowExA(NULL, iteratedHwnd, NULL, WHATSAPP_CLIENT_NAME);
-		if (iteratedHwnd == NULL) {
-			return NULL;
+		iteratedHwnd = FindWindowExA(nullptr, iteratedHwnd, nullptr, WHATSAPP_CLIENT_NAME);
+		if (iteratedHwnd == nullptr) {
+			outdated = true;
+			iteratedHwnd = FindWindowExA(nullptr, iteratedHwnd, nullptr, WHATSAPP_OUTDATED_CLIENT_NAME);
+			if (iteratedHwnd == nullptr) {
+				return nullptr;
+			}
 		}
 
 		auto windowTitle = Helper::GetWindowTitle(iteratedHwnd);
@@ -408,7 +413,8 @@ static HWND FindWhatsappWindowHandle()
 		}
 
 		// Also check length because compare also matches strings that are longer like 'WhatsApp Voip'. Not sure if that is true but i leave it for now...
-		if (windowTitle.compare(WHATSAPP_CLIENT_NAME) != 0 && windowTitle.length() == strlen(WHATSAPP_CLIENT_NAME)) {
+		if (windowTitle.compare(outdated ? WHATSAPP_OUTDATED_CLIENT_NAME : WHATSAPP_CLIENT_NAME) != 0 && 
+			windowTitle.length() == strlen(outdated ? WHATSAPP_OUTDATED_CLIENT_NAME : WHATSAPP_CLIENT_NAME)) {
 			LogInfo("Window name does not match");
 			continue;
 		}


### PR DESCRIPTION
…h v2.2314.11 onwards of the desktop app

Attached PR should fix app with most recent update to the desktop version of WA v2.2314.11 which has updated the window title to "WhatApp (Outdated)".  It should still work with the other version, but I cant test this as can no longer find anywhere to install it from.